### PR TITLE
Add shortcuts for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Load your last commit message into git commit box, or let you choose from last n
 
 **CTRL+I CTRL+L** - Let you choose from your last commit message and sets it as commit message
 
+### On macOS
+
+**CMD+K CMD+L** - Loads last commit message into commit message box
+
+**CMD+I CMD+L** - Let you choose from your last commit message and sets it as commit message
+
+Source: the `Keyboard Shortcuts` screen in Visual Studio Code
+
+![](https://i.imgur.com/Q7BNn11.png)
+
 ## Extension Settings
 
 ```


### PR DESCRIPTION
On macOS, the default shortcuts for last commit message and last N commit messages are different than the ones You point out in the README file.