### PR TITLE
Fixed glcm.chooseLastCommitMessage not working when there is only one repository

### DIFF
--- a/src/LastCommitMessage.ts
+++ b/src/LastCommitMessage.ts
@@ -36,8 +36,16 @@ export class LastCommitMessage {
         }
     }
 
+    private chooseRepository() {
+        if (this._gitAPI.repositories.length == 1) {
+            return this._gitAPI.repositories[0];
+        } else {
+            return this._gitAPI.repositories.find(x => x.ui.selected);
+        }
+    }
+
     async chooseLastCommitMessage() {
-        const selectedRep = this._gitAPI.repositories.find(x => x.ui.selected);
+        const selectedRep = this.chooseRepository();
         if (selectedRep != null) {
 
 


### PR DESCRIPTION
Supports the specification that repository.ui.selected is always false when there is only one repository.